### PR TITLE
getOrRemove did not check id property type

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "plugins": ["transform-object-assign", "add-module-exports"],
-  "presets": [ "es2015" ]
-}

--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
     "babel-preset-es2015": "^6.1.18",
     "jshint": "^2.6.3",
     "mocha": "^2.1.0"
+  },
+  "babel": {
+    "plugins": ["transform-object-assign", "add-module-exports"],
+    "presets": [ "es2015" ]
   }
 }

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -38,7 +38,7 @@ const getOrRemove = name => {
       throw new Error(`Too many arguments for '${name}' service method`);
     }
 
-    if(id === 'function') {
+    if(typeof id === 'function') {
       throw new Error(`First parameter for '${name}' can not be a function`);
     }
 

--- a/test/arguments.test.js
+++ b/test/arguments.test.js
@@ -23,6 +23,7 @@ describe('Argument normalization tests', () => {
 
     try {
       getArguments('find', normal.concat(['too many']));
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'Too many arguments for \'find\' service method');
     }
@@ -45,12 +46,14 @@ describe('Argument normalization tests', () => {
 
     try {
       getArguments('get', [callback]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'First parameter for \'get\' can not be a function');
     }
 
     try {
       getArguments('get', normal.concat(['too many']));
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'Too many arguments for \'get\' service method');
     }
@@ -73,12 +76,14 @@ describe('Argument normalization tests', () => {
 
     try {
       args = getArguments('remove', [callback]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'First parameter for \'remove\' can not be a function');
     }
 
     try {
       getArguments('remove', normal.concat(['too many']));
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'Too many arguments for \'remove\' service method');
     }
@@ -102,12 +107,14 @@ describe('Argument normalization tests', () => {
 
     try {
       getArguments('create', [callback]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'First parameter for \'create\' must be an object');
     }
 
     try {
       getArguments('create', normal.concat(['too many']));
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'Too many arguments for \'create\' service method');
     }
@@ -131,18 +138,21 @@ describe('Argument normalization tests', () => {
 
     try {
       getArguments('update', [callback]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'First parameter for \'update\' can not be a function');
     }
 
     try {
       getArguments('update', [5]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'No data provided for \'update\'');
     }
 
     try {
       getArguments('update', normal.concat(['too many']));
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'Too many arguments for \'update\' service method');
     }
@@ -166,18 +176,21 @@ describe('Argument normalization tests', () => {
 
     try {
       getArguments('patch', [callback]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'First parameter for \'patch\' can not be a function');
     }
 
     try {
       getArguments('patch', [5]);
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'No data provided for \'patch\'');
     }
 
     try {
       getArguments('patch', normal.concat(['too many']));
+      assert.ok(false);
     } catch(e) {
       assert.equal(e.message, 'Too many arguments for \'patch\' service method');
     }


### PR DESCRIPTION
The `getOrRemove` function did not have a `typeof` operator. Fixes that issue and also makes sure that all tests are covering thrown tests (which they didn't before).