### PR TITLE
Support socket routes with apps mounted on a path

### DIFF
--- a/src/commons.js
+++ b/src/commons.js
@@ -1,5 +1,5 @@
 import getArguments from './arguments';
-import socket from './sockets/index';
+import * as socket from './sockets/index';
 import { stripSlashes } from './utils';
 import hooks from './hooks';
 

--- a/src/sockets/helpers.js
+++ b/src/sockets/helpers.js
@@ -21,7 +21,7 @@ export function defaultDispatcher(data, params, callback) {
 }
 
 // Set up event handlers for a given service using the event dispatching mechanism
-export function setupEventHandlers(info, service, path) {
+export function setupEventHandlers(info, path, service) {
   // If the service emits events that we want to listen to (Event mixin)
   if (typeof service.on !== 'function' || !service._serviceEvents) {
     return;
@@ -48,7 +48,7 @@ export function setupEventHandlers(info, service, path) {
 }
 
 // Set up all method handlers for a service and socket.
-export function setupMethodHandlers(info, socket, service, path) {
+export function setupMethodHandlers(info, socket, path, service) {
   this.methods.forEach(function (method) {
     if (typeof service[method] !== 'function') {
       return;

--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -1,41 +1,62 @@
 import { stripSlashes, each } from '../utils';
 import { setupEventHandlers, setupMethodHandlers } from './helpers';
 
+export function getPath(app, path) {
+  const mountpath = app.mountpath !== '/' ? app.mountpath : '';
+
+  return stripSlashes(`${mountpath}/${path}`);
+}
+
+export function handleMount(app) {
+  // When mounted as a sub-app, override the parent setup so you don't have to call it
+  app.on('mount', parent => {
+    const oldSetup = parent.setup;
+
+    parent.setup = function(... args) {
+      const result = oldSetup.apply(this, args);
+      app.setup(... args);
+      return result;
+    };
+  });
+}
+
 // Common setup functionality taking the info object which abstracts websocket access
 export function setup(info) {
-  let _setupEventHandlers = setupEventHandlers.bind(this, info);
+  const app = this;
 
-  this._commons = info;
+  app._commons = info;
 
   // For a new connection, set up the service method handlers
-  info.connection().on('connection', socket => {
-    let _setupMethodHandlers = setupMethodHandlers.bind(this, info, socket);
+  info.connection().on('connection', socket =>
     // Process all registered services
-    each(this.services, _setupMethodHandlers);
-  });
+    each(app.services, (service, path) =>
+      setupMethodHandlers.call(app, info, socket, getPath(app, path), service)
+    )
+  );
 
   // Set up events and event dispatching
-  each(this.services, _setupEventHandlers);
+  each(app.services, (service, path) =>
+    setupEventHandlers.call(app, info, getPath(app, path), service)
+  );
 }
 
 // Socket mixin when a new service is registered
 export function service(path, obj) {
-  let protoService = this._super.apply(this, arguments);
-  let info = this._commons;
+  const app = this;
+  const protoService = this._super.apply(this, arguments);
+  const info = this._commons;
 
   // app._socketInfo will only be available once we are set up
   if (obj && info) {
-    let _setupEventHandlers = setupEventHandlers.bind(this, info);
-    let _setupMethodHandlers = setupMethodHandlers.bind(this, info);
-    let location = stripSlashes(path);
+    const location = stripSlashes(path);
 
     // Set up event handlers for this new service
-    _setupEventHandlers(protoService, location);
+    setupEventHandlers.call(app, info, getPath(app, location), protoService);
     // For any existing connection add method handlers
-    each(info.clients(), socket => _setupMethodHandlers(socket, location, protoService));
+    each(info.clients(), socket =>
+      setupMethodHandlers.call(app, socket, getPath(app, location), protoService)
+    );
   }
 
   return protoService;
 }
-
-export default { setup, service };


### PR DESCRIPTION
This pull request makes it possible to mount a Feathers sub-application and get the websocket api routes updated. For example with

```
import api from './api';

app.use('/api', api);

app.listen(8080);
```

when `api` has a `todos` service, the service path for socket method calls and events on the app server will now be `api/todos`.

Closes https://github.com/feathersjs/feathers/issues/199