### PR TITLE
omit '$select' in matcher

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -62,7 +62,7 @@ export const specialFilters = {
 };
 
 export function matcher(originalQuery) {
-  const query = _.omit(originalQuery, '$limit', '$skip', '$sort');
+  const query = _.omit(originalQuery, '$limit', '$skip', '$sort', '$select');
 
   return function(item) {
     if(query.$or && _.some(query.$or, or => matcher(or)(item))) {


### PR DESCRIPTION
Fixed a bug in the `matcher` function. Omit `'$select'` together with `'$limit', '$skip', '$sort'`. Otherwise it always fails to match when `$select` is present in the query.