### PR TITLE
Fixing select utility methods to work with query selector

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -90,23 +90,13 @@ export const specialFilters = {
   }
 };
 
-export function select (...fields) {
-  return result => _.pick(result, ...fields);
-}
-
-export function selectMany (...fields) {
-  const selector = select(...fields);
-
-  return function (result) {
-    if (Array.isArray(result)) {
-      return result.map(selector);
+export function select (fields) {
+  return result => {
+    if (!(fields && Array.isArray(fields))) {
+      return result;
     }
 
-    if (result.data) {
-      result.data = result.data.map(selector);
-    }
-
-    return result;
+    return _.pick(result, ...fields);
   };
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,9 +90,11 @@ export const specialFilters = {
   }
 };
 
-export function select (fields) {
+export function select (params) {
+  const fields = params && params.query && params.query.$select;
+
   return result => {
-    if (!(fields && Array.isArray(fields))) {
+    if (!fields || !Array.isArray(fields)) {
       return result;
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,11 +90,15 @@ export const specialFilters = {
   }
 };
 
-export function select (params) {
+export function select (params, ...otherFields) {
   const fields = params && params.query && params.query.$select;
 
+  if (Array.isArray(fields) && otherFields.length) {
+    fields.push(...otherFields);
+  }
+
   return result => {
-    if (!fields || !Array.isArray(fields)) {
+    if (!Array.isArray(fields)) {
       return result;
     }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,8 +2,7 @@ if (!global._babelPolyfill) { require('babel-polyfill'); }
 
 import assert from 'assert';
 import {
-  _, specialFilters, sorter, matcher,
-  stripSlashes, select, selectMany
+  _, specialFilters, sorter, matcher, stripSlashes, select
 } from '../src/utils';
 
 describe('feathers-commons utils', () => {
@@ -99,9 +98,9 @@ describe('feathers-commons utils', () => {
     });
   });
 
-  describe('selecting', () => {
+  describe('select', () => {
     it('select', () => {
-      const selector = select('name', 'age');
+      const selector = select(['name', 'age']);
 
       return Promise.resolve({
         name: 'David',
@@ -115,38 +114,15 @@ describe('feathers-commons utils', () => {
       }));
     });
 
-    it('selectMany', () => {
-      const selector = selectMany('name', 'age');
+    it('select with no arguments', () => {
+      const selector = select();
+      const data = {
+        name: 'David'
+      };
 
-      return Promise.resolve([{
-        name: 'David',
-        age: 3,
-        test: 'me'
-      }])
+      return Promise.resolve(data)
       .then(selector)
-      .then(result => assert.deepEqual(result, [{
-        name: 'David',
-        age: 3
-      }]));
-    });
-
-    it('selectMany paginated', () => {
-      const selector = selectMany('name', 'age');
-
-      return Promise.resolve({
-        data: [{
-          name: 'David',
-          age: 3,
-          test: 'me'
-        }]
-      })
-      .then(selector)
-      .then(result => assert.deepEqual(result, {
-        data: [{
-          name: 'David',
-          age: 3
-        }]
-      }));
+      .then(result => assert.deepEqual(result, data));
     });
   });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -100,7 +100,9 @@ describe('feathers-commons utils', () => {
 
   describe('select', () => {
     it('select', () => {
-      const selector = select(['name', 'age']);
+      const selector = select({
+        query: { $select: ['name', 'age'] }
+      });
 
       return Promise.resolve({
         name: 'David',
@@ -114,8 +116,8 @@ describe('feathers-commons utils', () => {
       }));
     });
 
-    it('select with no arguments', () => {
-      const selector = select();
+    it('select with no query', () => {
+      const selector = select({});
       const data = {
         name: 'David'
       };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -126,6 +126,24 @@ describe('feathers-commons utils', () => {
       .then(selector)
       .then(result => assert.deepEqual(result, data));
     });
+
+    it('select with other fields', () => {
+      const selector = select({
+        query: { $select: [ 'name' ] }
+      }, 'id');
+      const data = {
+        id: 'me',
+        name: 'David',
+        age: 10
+      };
+
+      return Promise.resolve(data)
+      .then(selector)
+      .then(result => assert.deepEqual(result, {
+        id: 'me',
+        name: 'David'
+      }));
+    });
   });
 
   describe('specialFilters', () => {


### PR DESCRIPTION
This is not used anywhere yet so we can change it before using it for the db adapters (see https://github.com/feathersjs/feathers-service-tests/pull/32)