### PR TITLE
Expect syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "chai": "^3.5.0",
     "eslint-if-supported": "^1.0.1",
     "istanbul": "^1.1.0-alpha.1",
-    "jshint": "^2.6.3",
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",
     "semistandard": "^9.1.0"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-plugin-transform-object-assign": "^6.1.18",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.1.18",
+    "chai": "^3.5.0",
     "eslint-if-supported": "^1.0.1",
     "istanbul": "^1.1.0-alpha.1",
     "jshint": "^2.6.3",

--- a/test/arguments.test.js
+++ b/test/arguments.test.js
@@ -1,6 +1,6 @@
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
-import assert from 'assert';
+import { expect } from 'chai';
 import getArguments, { noop } from '../src/arguments';
 
 describe('Argument normalization tests', () => {
@@ -11,22 +11,22 @@ describe('Argument normalization tests', () => {
     let normal = [ params, callback ];
     let args = getArguments('find', normal);
 
-    assert.deepEqual(args, normal);
+    expect(args).to.deep.equal(normal);
 
     args = getArguments('find', [ params ]);
-    assert.deepEqual(args, [ params, noop ]);
+    expect(args).to.deep.equal([ params, noop ]);
 
     args = getArguments('find', [callback]);
-    assert.deepEqual(args, [ {}, callback ]);
+    expect(args).to.deep.equal([ {}, callback ]);
 
     args = getArguments('find', []);
-    assert.deepEqual(args, [ {}, noop ]);
+    expect(args).to.deep.equal([ {}, noop ]);
 
     try {
       getArguments('find', normal.concat(['too many']));
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'Too many arguments for \'find\' service method');
+      expect(e.message).equal('Too many arguments for \'find\' service method');
     }
   });
 
@@ -34,29 +34,29 @@ describe('Argument normalization tests', () => {
     let normal = [1, params, callback];
     let args = getArguments('get', normal);
 
-    assert.deepEqual(args, normal);
+    expect(args).to.deep.equal(normal);
 
     args = getArguments('get', [2, params]);
-    assert.deepEqual(args, [2, params, noop]);
+    expect(args).to.deep.equal([2, params, noop]);
 
     args = getArguments('get', [3, callback]);
-    assert.deepEqual(args, [3, {}, callback]);
+    expect(args).to.deep.equal([3, {}, callback]);
 
     args = getArguments('get', [4]);
-    assert.deepEqual(args, [4, {}, noop]);
+    expect(args).to.deep.equal([4, {}, noop]);
 
     try {
       getArguments('get', [callback]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'First parameter for \'get\' can not be a function');
+      expect(e.message).equal('First parameter for \'get\' can not be a function');
     }
 
     try {
       getArguments('get', normal.concat(['too many']));
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'Too many arguments for \'get\' service method');
+      expect(e.message).equal('Too many arguments for \'get\' service method');
     }
   });
 
@@ -64,29 +64,29 @@ describe('Argument normalization tests', () => {
     let normal = [1, params, callback];
     let args = getArguments('remove', normal);
 
-    assert.deepEqual(args, normal);
+    expect(args).to.deep.equal(normal);
 
     args = getArguments('remove', [2, params]);
-    assert.deepEqual(args, [2, params, noop]);
+    expect(args).to.deep.equal([2, params, noop]);
 
     args = getArguments('remove', [3, callback]);
-    assert.deepEqual(args, [3, {}, callback]);
+    expect(args).to.deep.equal([3, {}, callback]);
 
     args = getArguments('remove', [4]);
-    assert.deepEqual(args, [4, {}, noop]);
+    expect(args).to.deep.equal([4, {}, noop]);
 
     try {
       args = getArguments('remove', [callback]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'First parameter for \'remove\' can not be a function');
+      expect(e.message).equal('First parameter for \'remove\' can not be a function');
     }
 
     try {
       getArguments('remove', normal.concat(['too many']));
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'Too many arguments for \'remove\' service method');
+      expect(e.message).equal('Too many arguments for \'remove\' service method');
     }
   });
 
@@ -95,29 +95,29 @@ describe('Argument normalization tests', () => {
     let normal = [data, params, callback];
     let args = getArguments('create', normal);
 
-    assert.deepEqual(args, normal);
+    expect(args).to.deep.equal(normal);
 
     args = getArguments('create', [data, callback]);
-    assert.deepEqual(args, [data, {}, callback]);
+    expect(args).to.deep.equal([data, {}, callback]);
 
     args = getArguments('create', [data, params]);
-    assert.deepEqual(args, [data, params, noop]);
+    expect(args).to.deep.equal([data, params, noop]);
 
     args = getArguments('create', [data]);
-    assert.deepEqual(args, [data, {}, noop]);
+    expect(args).to.deep.equal([data, {}, noop]);
 
     try {
       getArguments('create', [callback]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'First parameter for \'create\' must be an object');
+      expect(e.message).equal('First parameter for \'create\' must be an object');
     }
 
     try {
       getArguments('create', normal.concat(['too many']));
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'Too many arguments for \'create\' service method');
+      expect(e.message).equal('Too many arguments for \'create\' service method');
     }
   });
 
@@ -126,36 +126,36 @@ describe('Argument normalization tests', () => {
     let normal = [1, data, params, callback];
     let args = getArguments('update', normal);
 
-    assert.deepEqual(args, normal);
+    expect(args).to.deep.equal(normal);
 
     args = getArguments('update', [2, data, callback]);
-    assert.deepEqual(args, [2, data, {}, callback]);
+    expect(args).to.deep.equal([2, data, {}, callback]);
 
     args = getArguments('update', [3, data, params]);
-    assert.deepEqual(args, [3, data, params, noop]);
+    expect(args).to.deep.equal([3, data, params, noop]);
 
     args = getArguments('update', [4, data]);
-    assert.deepEqual(args, [4, data, {}, noop]);
+    expect(args).to.deep.equal([4, data, {}, noop]);
 
     try {
       getArguments('update', [callback]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'First parameter for \'update\' can not be a function');
+      expect(e.message).equal('First parameter for \'update\' can not be a function');
     }
 
     try {
       getArguments('update', [5]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'No data provided for \'update\'');
+      expect(e.message).equal('No data provided for \'update\'');
     }
 
     try {
       getArguments('update', normal.concat(['too many']));
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'Too many arguments for \'update\' service method');
+      expect(e.message).equal('Too many arguments for \'update\' service method');
     }
   });
 
@@ -164,36 +164,36 @@ describe('Argument normalization tests', () => {
     let normal = [1, data, params, callback];
     let args = getArguments('patch', normal);
 
-    assert.deepEqual(args, normal);
+    expect(args).to.deep.equal(normal);
 
     args = getArguments('patch', [2, data, callback]);
-    assert.deepEqual(args, [2, data, {}, callback]);
+    expect(args).to.deep.equal([2, data, {}, callback]);
 
     args = getArguments('patch', [3, data, params]);
-    assert.deepEqual(args, [3, data, params, noop]);
+    expect(args).to.deep.equal([3, data, params, noop]);
 
     args = getArguments('patch', [4, data]);
-    assert.deepEqual(args, [4, data, {}, noop]);
+    expect(args).to.deep.equal([4, data, {}, noop]);
 
     try {
       getArguments('patch', [callback]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'First parameter for \'patch\' can not be a function');
+      expect(e.message).equal('First parameter for \'patch\' can not be a function');
     }
 
     try {
       getArguments('patch', [5]);
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'No data provided for \'patch\'');
+      expect(e.message).equal('No data provided for \'patch\'');
     }
 
     try {
       getArguments('patch', normal.concat(['too many']));
-      assert.ok(false);
+      expect(false).to.be.ok;
     } catch (e) {
-      assert.equal(e.message, 'Too many arguments for \'patch\' service method');
+      expect(e.message).equal('Too many arguments for \'patch\' service method');
     }
   });
 });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,6 +1,6 @@
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
-import assert from 'assert';
+import { expect } from 'chai';
 
 import { noop } from '../src/arguments';
 import utils from '../src/hooks';
@@ -11,7 +11,7 @@ describe('hook utilities', () => {
       { some: 'thing' }, noop
     ]);
     // find
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       params: { some: 'thing' },
       method: 'find',
       type: 'test',
@@ -24,7 +24,7 @@ describe('hook utilities', () => {
         { some: 'thing' }, noop
     ], dummyApp);
 
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       params: { some: 'thing' },
       method: 'find',
       type: 'test',
@@ -38,7 +38,7 @@ describe('hook utilities', () => {
       1, { some: 'thing' }, noop
     ]);
 
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       id: 1,
       params: { some: 'thing' },
       method: 'get',
@@ -51,7 +51,7 @@ describe('hook utilities', () => {
       1, { some: 'thing' }, noop
     ]);
 
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       id: 1,
       params: { some: 'thing' },
       method: 'remove',
@@ -64,7 +64,7 @@ describe('hook utilities', () => {
       { my: 'data' }, { some: 'thing' }, noop
     ]);
 
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       data: { my: 'data' },
       params: { some: 'thing' },
       method: 'create',
@@ -77,7 +77,7 @@ describe('hook utilities', () => {
       2, { my: 'data' }, { some: 'thing' }, noop
     ]);
 
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       id: 2,
       data: { my: 'data' },
       params: { some: 'thing' },
@@ -91,7 +91,7 @@ describe('hook utilities', () => {
       2, { my: 'data' }, { some: 'thing' }, noop
     ]);
 
-    assert.deepEqual(hookObject, {
+    expect(hookObject).to.deep.equal({
       id: 2,
       data: { my: 'data' },
       params: { some: 'thing' },
@@ -110,7 +110,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [2, { my: 'data' }, { some: 'thing' }, noop]);
+    expect(args).to.deep.equal([2, { my: 'data' }, { some: 'thing' }, noop]);
 
     args = utils.makeArguments({
       id: 0,
@@ -120,7 +120,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [0, { my: 'data' }, { some: 'thing' }, noop]);
+    expect(args).to.deep.equal([0, { my: 'data' }, { some: 'thing' }, noop]);
 
     args = utils.makeArguments({
       params: { some: 'thing' },
@@ -128,7 +128,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [
+    expect(args).to.deep.equal([
       { some: 'thing' },
       noop
     ]);
@@ -142,7 +142,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [
+    expect(args).to.deep.equal([
       { test: 'me' },
       { some: 'thing' },
       noop
@@ -154,7 +154,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [
+    expect(args).to.deep.equal([
       'testing', {}, noop
     ]);
   });
@@ -167,7 +167,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [undefined, { my: 'data' }, { some: 'thing' }, noop]);
+    expect(args).to.deep.equal([undefined, { my: 'data' }, { some: 'thing' }, noop]);
 
     args = utils.makeArguments({
       id: 2,
@@ -177,7 +177,7 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [2, { some: 'thing' }, noop]);
+    expect(args).to.deep.equal([2, { some: 'thing' }, noop]);
 
     args = utils.makeArguments({
       id: 2,
@@ -187,23 +187,24 @@ describe('hook utilities', () => {
       callback: noop
     });
 
-    assert.deepEqual(args, [{ my: 'data' }, { some: 'thing' }, noop]);
+    expect(args).to.deep.equal([{ my: 'data' }, { some: 'thing' }, noop]);
   });
 
   it('.convertHookData', () => {
-    assert.deepEqual(utils.convertHookData('test'), {
+    expect(utils.convertHookData('test')).to.deep.equal({
       all: [ 'test' ]
     });
 
-    assert.deepEqual(utils.convertHookData([ 'test', 'me' ]), {
+    expect(utils.convertHookData([ 'test', 'me' ])).to.deep.equal({
       all: [ 'test', 'me' ]
     });
 
-    assert.deepEqual(utils.convertHookData({
+    expect(utils.convertHookData({
       all: 'thing',
       other: 'value',
       hi: [ 'foo', 'bar' ]
-    }), {
+    }))
+    .to.deep.equal({
       all: [ 'thing' ],
       other: [ 'value' ],
       hi: [ 'foo', 'bar' ]

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1,13 +1,13 @@
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
-import assert from 'assert';
+import { expect } from 'chai';
 
 describe('build', () => {
   it('it build and exported', () => {
     let commons = require('../lib/commons');
-    assert.equal(typeof commons, 'object');
-    assert.equal(typeof commons.getArguments, 'function');
-    assert.equal(typeof commons.stripSlashes, 'function');
-    assert.equal(typeof commons.hooks, 'object');
+    expect(typeof commons).to.equal('object');
+    expect(typeof commons.getArguments).to.equal('function');
+    expect(typeof commons.stripSlashes).to.equal('function');
+    expect(typeof commons.hooks).to.equal('object');
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,97 +1,95 @@
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
-import assert from 'assert';
+import { expect } from 'chai';
 import {
   _, specialFilters, sorter, matcher, stripSlashes, select
 } from '../src/utils';
 
 describe('feathers-commons utils', () => {
   it('stripSlashes', () => {
-    assert.equal(stripSlashes('some/thing'), 'some/thing');
-    assert.equal(stripSlashes('/some/thing'), 'some/thing');
-    assert.equal(stripSlashes('some/thing/'), 'some/thing');
-    assert.equal(stripSlashes('/some/thing/'), 'some/thing');
-    assert.equal(stripSlashes('//some/thing/'), 'some/thing');
-    assert.equal(stripSlashes('//some//thing////'), 'some//thing');
+    expect(stripSlashes('some/thing')).to.equal('some/thing');
+    expect(stripSlashes('/some/thing')).to.equal('some/thing');
+    expect(stripSlashes('some/thing/')).to.equal('some/thing');
+    expect(stripSlashes('/some/thing/')).to.equal('some/thing');
+    expect(stripSlashes('//some/thing/')).to.equal('some/thing');
+    expect(stripSlashes('//some//thing////')).to.equal('some//thing');
   });
 
   describe('_', () => {
     it('each', () => {
       _.each({ hi: 'there' }, (value, key) => {
-        assert.equal(key, 'hi');
-        assert.equal(value, 'there');
+        expect(key).to.equal('hi');
+        expect(value).to.equal('there');
       });
 
       _.each([ 'hi' ], (value, key) => {
-        assert.equal(key, 0);
-        assert.equal(value, 'hi');
+        expect(key).to.equal(0);
+        expect(value).to.equal('hi');
       });
     });
 
     it('some', () => {
-      assert.ok(_.some([ 'a', 'b' ], current => current === 'a'));
-      assert.ok(!_.some([ 'a', 'b' ], current => current === 'c'));
+      expect(_.some([ 'a', 'b' ], current => current === 'a')).to.be.ok;
+      expect(!_.some([ 'a', 'b' ], current => current === 'c')).to.be.ok;
     });
 
     it('every', () => {
-      assert.ok(_.every([ 'a', 'a' ], current => current === 'a'));
-      assert.ok(!_.every([ 'a', 'b' ], current => current === 'a'));
+      expect(_.every([ 'a', 'a' ], current => current === 'a')).to.be.ok;
+      expect(!_.every([ 'a', 'b' ], current => current === 'a')).to.be.ok;
     });
 
     it('keys', () => {
       const data = { hi: 'there', name: 'David' };
-
-      assert.deepEqual(_.keys(data), [ 'hi', 'name' ]);
+      expect(_.keys(data)).to.deep.equal([ 'hi', 'name' ]);
     });
 
     it('values', () => {
       const data = { hi: 'there', name: 'David' };
-
-      assert.deepEqual(_.values(data), [ 'there', 'David' ]);
+      expect(_.values(data)).to.deep.equal([ 'there', 'David' ]);
     });
 
     it('isMatch', () => {
-      assert.ok(_.isMatch({
+      expect(_.isMatch({
         test: 'me', hi: 'you', more: true
       }, {
         test: 'me', hi: 'you'
-      }));
+      })).to.be.ok;
 
-      assert.ok(!_.isMatch({
+      expect(!_.isMatch({
         test: 'me', hi: 'you', more: true
       }, {
         test: 'me', hi: 'there'
-      }));
+      })).to.be.ok;
     });
 
     it('isEmpty', () => {
-      assert.ok(_.isEmpty({}));
-      assert.ok(!_.isEmpty({ name: 'David' }));
+      expect(_.isEmpty({})).to.be.ok;
+      expect(!_.isEmpty({ name: 'David' })).to.be.ok;
     });
 
     it('extend', () => {
-      assert.deepEqual(_.extend({ hi: 'there' }, { name: 'david' }), {
+      expect(_.extend({ hi: 'there' }, { name: 'david' })).to.deep.equal({
         hi: 'there',
         name: 'david'
       });
     });
 
     it('omit', () => {
-      assert.deepEqual(_.omit({
+      expect(_.omit({
         name: 'David',
         first: 1,
         second: 2
-      }, 'first', 'second'), {
+      }, 'first', 'second')).to.deep.equal({
         name: 'David'
       });
     });
 
     it('pick', () => {
-      assert.deepEqual(_.pick({
+      expect(_.pick({
         name: 'David',
         first: 1,
         second: 2
-      }, 'first', 'second'), {
+      }, 'first', 'second')).to.deep.equal({
         first: 1,
         second: 2
       });
@@ -110,7 +108,7 @@ describe('feathers-commons utils', () => {
         test: 'me'
       })
       .then(selector)
-      .then(result => assert.deepEqual(result, {
+      .then(result => expect(result).to.deep.equal({
         name: 'David',
         age: 3
       }));
@@ -131,7 +129,7 @@ describe('feathers-commons utils', () => {
         test: 'you'
       }])
       .then(selector)
-      .then(result => assert.deepEqual(result, [{
+      .then(result => expect(result).to.deep.equal([{
         name: 'David',
         age: 3
       }, {
@@ -148,7 +146,7 @@ describe('feathers-commons utils', () => {
 
       return Promise.resolve(data)
       .then(selector)
-      .then(result => assert.deepEqual(result, data));
+      .then(result => expect(result).to.deep.equal(data));
     });
 
     it('select with other fields', () => {
@@ -163,7 +161,7 @@ describe('feathers-commons utils', () => {
 
       return Promise.resolve(data)
       .then(selector)
-      .then(result => assert.deepEqual(result, {
+      .then(result => expect(result).to.deep.equal({
         id: 'me',
         name: 'David'
       }));
@@ -176,54 +174,54 @@ describe('feathers-commons utils', () => {
     it('$in', () => {
       const fn = filters.$in('test', ['a', 'b']);
 
-      assert.ok(fn({ test: 'a' }));
-      assert.ok(!fn({ test: 'c' }));
+      expect(fn({ test: 'a' })).to.be.ok;
+      expect(!fn({ test: 'c' })).to.be.ok;
     });
 
     it('$nin', () => {
       const fn = filters.$nin('test', ['a', 'b']);
 
-      assert.ok(!fn({ test: 'a' }));
-      assert.ok(fn({ test: 'c' }));
+      expect(!fn({ test: 'a' })).to.be.ok;
+      expect(fn({ test: 'c' })).to.be.ok;
     });
 
     it('$lt', () => {
       const fn = filters.$lt('age', 25);
 
-      assert.ok(fn({ age: 24 }));
-      assert.ok(!fn({ age: 25 }));
-      assert.ok(!fn({ age: 26 }));
+      expect(fn({ age: 24 })).to.be.ok;
+      expect(!fn({ age: 25 })).to.be.ok;
+      expect(!fn({ age: 26 })).to.be.ok;
     });
 
     it('$lte', () => {
       const fn = filters.$lte('age', 25);
 
-      assert.ok(fn({ age: 24 }));
-      assert.ok(fn({ age: 25 }));
-      assert.ok(!fn({ age: 26 }));
+      expect(fn({ age: 24 })).to.be.ok;
+      expect(fn({ age: 25 })).to.be.ok;
+      expect(!fn({ age: 26 })).to.be.ok;
     });
 
     it('$gt', () => {
       const fn = filters.$gt('age', 25);
 
-      assert.ok(!fn({ age: 24 }));
-      assert.ok(!fn({ age: 25 }));
-      assert.ok(fn({ age: 26 }));
+      expect(!fn({ age: 24 })).to.be.ok;
+      expect(!fn({ age: 25 })).to.be.ok;
+      expect(fn({ age: 26 })).to.be.ok;
     });
 
     it('$gte', () => {
       const fn = filters.$gte('age', 25);
 
-      assert.ok(!fn({ age: 24 }));
-      assert.ok(fn({ age: 25 }));
-      assert.ok(fn({ age: 26 }));
+      expect(!fn({ age: 24 })).to.be.ok;
+      expect(fn({ age: 25 })).to.be.ok;
+      expect(fn({ age: 26 })).to.be.ok;
     });
 
     it('$ne', () => {
       const fn = filters.$ne('test', 'me');
 
-      assert.ok(fn({ test: 'you' }));
-      assert.ok(!fn({ test: 'me' }));
+      expect(fn({ test: 'you' })).to.be.ok;
+      expect(!fn({ test: 'me' })).to.be.ok;
     });
   });
 
@@ -239,7 +237,7 @@ describe('feathers-commons utils', () => {
         name: -1
       });
 
-      assert.deepEqual(array.sort(sort), [{
+      expect(array.sort(sort)).to.deep.equal([{
         name: 'Eric'
       }, {
         name: 'David'
@@ -266,7 +264,7 @@ describe('feathers-commons utils', () => {
         counter: 1
       });
 
-      assert.deepEqual(array.sort(sort), [
+      expect(array.sort(sort)).to.deep.equal([
         { name: 'Eric', counter: 0 },
         { name: 'David', counter: 0 },
         { name: 'Eric', counter: 1 },
@@ -279,22 +277,21 @@ describe('feathers-commons utils', () => {
     it('simple match', () => {
       const matches = matcher({ name: 'Eric' });
 
-      assert.ok(matches({ name: 'Eric' }));
-      assert.ok(!matches({ name: 'David' }));
+      expect(matches({ name: 'Eric' })).to.be.ok;
+      expect(!matches({ name: 'David' })).to.be.ok;
     });
 
     it('does not match $select', () => {
       const matches = matcher({ $select: [ 'name' ] });
-
-      assert.ok(matches({ name: 'Eric' }));
+      expect(matches({ name: 'Eric' })).to.be.ok;
     });
 
     it('$or match', () => {
       const matches = matcher({ $or: [{ name: 'Eric' }, { name: 'Marshall' }] });
 
-      assert.ok(matches({ name: 'Eric' }));
-      assert.ok(matches({ name: 'Marshall' }));
-      assert.ok(!matches({ name: 'David' }));
+      expect(matches({ name: 'Eric' })).to.be.ok;
+      expect(matches({ name: 'Marshall' })).to.be.ok;
+      expect(!matches({ name: 'David' })).to.be.ok;
     });
 
     it('$or nested match', () => {
@@ -305,16 +302,10 @@ describe('feathers-commons utils', () => {
         ]
       });
 
-      assert.ok(matches({ name: 'Eric' }));
-      assert.ok(matches({ age: 20 }));
-      assert.ok(matches({
-        name: 'David',
-        age: 30
-      }));
-      assert.ok(!matches({
-        name: 'David',
-        age: 64
-      }));
+      expect(matches({ name: 'Eric' })).to.be.ok;
+      expect(matches({ age: 20 })).to.be.ok;
+      expect(matches({ name: 'David', age: 30 })).to.be.ok;
+      expect(!matches({ name: 'David', age: 64 })).to.be.ok;
     });
 
     it('special filter matches', () => {
@@ -323,9 +314,9 @@ describe('feathers-commons utils', () => {
         name: { $in: ['Eric', 'Marshall'] }
       });
 
-      assert.ok(matches({ name: 'Eric', counter: 12 }));
-      assert.ok(!matches({ name: 'Eric', counter: 10 }));
-      assert.ok(matches({ name: 'Marshall', counter: 19 }));
+      expect(matches({ name: 'Eric', counter: 12 })).to.be.ok;
+      expect(!matches({ name: 'Eric', counter: 10 })).to.be.ok;
+      expect(matches({ name: 'Marshall', counter: 19 })).to.be.ok;
     });
 
     it('special filter and simple matches', () => {
@@ -334,8 +325,8 @@ describe('feathers-commons utils', () => {
         name: { $in: ['Eric', 'Marshall'] }
       });
 
-      assert.ok(!matches({ name: 'Eric', counter: 1 }));
-      assert.ok(matches({ name: 'Marshall', counter: 0 }));
+      expect(!matches({ name: 'Eric', counter: 1 })).to.be.ok;
+      expect(matches({ name: 'Marshall', counter: 0 })).to.be.ok;
     });
   });
 });


### PR DESCRIPTION
removing jshint dependency and converting to chai `expect`syntax for consistency. I have a follow up PR that adds a `makeUrl`util function to build fully qualified urls with or without the app object.