### PR TITLE
Expose lodash functions

### DIFF
--- a/src/commons.js
+++ b/src/commons.js
@@ -2,11 +2,19 @@ import getArguments from './arguments';
 import {
   stripSlashes,
   each,
+  some,
+  every,
+  keys,
+  values,
+  isMatch,
+  isEmpty,
+  extend,
+  omit,
+  pick,
   matcher,
   sorter,
   _,
   select,
-  selectMany,
   makeUrl
 } from './utils';
 import hooks from './hooks';
@@ -16,10 +24,18 @@ export default {
   getArguments,
   stripSlashes,
   each,
+  some,
+  every,
+  keys,
+  values,
+  isMatch,
+  isEmpty,
+  extend,
+  omit,
+  pick,
   hooks,
   matcher,
   sorter,
   select,
-  selectMany,
   makeUrl
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,54 +10,63 @@ export function each (obj, callback) {
   }
 }
 
+export function some (value, callback) {
+  return Object.keys(value)
+    .map(key => [ value[key], key ])
+    .some(current => callback(...current));
+}
+
+export function every (value, callback) {
+  return Object.keys(value)
+    .map(key => [ value[key], key ])
+    .every(current => callback(...current));
+}
+
+export function keys (obj) {
+  return Object.keys(obj);
+}
+
+export function values (obj) {
+  return _.keys(obj).map(key => obj[key]);
+}
+
+export function isMatch (obj, item) {
+  return _.keys(item).every(key => obj[key] === item[key]);
+}
+
+export function isEmpty (obj) {
+  return _.keys(obj).length === 0;
+}
+
+export function extend (...args) {
+  return Object.assign(...args);
+}
+
+export function omit (obj, ...keys) {
+  const result = _.extend({}, obj);
+  keys.forEach(key => delete result[key]);
+  return result;
+}
+
+export function pick (source, ...keys) {
+  const result = {};
+  keys.forEach(key => {
+    result[key] = source[key];
+  });
+  return result;
+}
+
 export const _ = {
   each,
-
-  some (value, callback) {
-    return Object.keys(value)
-      .map(key => [ value[key], key ])
-      .some(current => callback(...current));
-  },
-
-  every (value, callback) {
-    return Object.keys(value)
-      .map(key => [ value[key], key ])
-      .every(current => callback(...current));
-  },
-
-  keys (obj) {
-    return Object.keys(obj);
-  },
-
-  values (obj) {
-    return _.keys(obj).map(key => obj[key]);
-  },
-
-  isMatch (obj, item) {
-    return _.keys(item).every(key => obj[key] === item[key]);
-  },
-
-  isEmpty (obj) {
-    return _.keys(obj).length === 0;
-  },
-
-  extend (...args) {
-    return Object.assign(...args);
-  },
-
-  omit (obj, ...keys) {
-    const result = _.extend({}, obj);
-    keys.forEach(key => delete result[key]);
-    return result;
-  },
-
-  pick (source, ...keys) {
-    const result = {};
-    keys.forEach(key => {
-      result[key] = source[key];
-    });
-    return result;
-  }
+  some,
+  every,
+  keys,
+  values,
+  isMatch,
+  isEmpty,
+  extend,
+  omit,
+  pick
 };
 
 export const specialFilters = {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1,13 +1,73 @@
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
 import { expect } from 'chai';
+import {
+  getArguments,
+  stripSlashes,
+  hooks,
+  _,
+  matcher,
+  sorter,
+  select,
+  // lodash methods
+  each,
+  some,
+  every,
+  keys,
+  values,
+  isMatch,
+  isEmpty,
+  extend,
+  omit,
+  pick
+} from '../src/commons';
 
 describe('build', () => {
-  it('it build and exported', () => {
+  it('is commonjs compatible', () => {
     let commons = require('../lib/commons');
     expect(typeof commons).to.equal('object');
     expect(typeof commons.getArguments).to.equal('function');
     expect(typeof commons.stripSlashes).to.equal('function');
+    expect(typeof commons.matcher).to.equal('function');
+    expect(typeof commons.sorter).to.equal('function');
+    expect(typeof commons.select).to.equal('function');
     expect(typeof commons.hooks).to.equal('object');
+    expect(typeof commons._).to.equal('object');
+  });
+
+  it('is es6 compatible', () => {
+    expect(typeof getArguments).to.equal('function');
+    expect(typeof stripSlashes).to.equal('function');
+    expect(typeof matcher).to.equal('function');
+    expect(typeof sorter).to.equal('function');
+    expect(typeof select).to.equal('function');
+    expect(typeof hooks).to.equal('object');
+    expect(typeof _).to.equal('object');
+  });
+
+  it('exposes lodash methods top level', () => {
+    expect(typeof each).to.equal('function');
+    expect(typeof some).to.equal('function');
+    expect(typeof every).to.equal('function');
+    expect(typeof keys).to.equal('function');
+    expect(typeof values).to.equal('function');
+    expect(typeof isMatch).to.equal('function');
+    expect(typeof isEmpty).to.equal('function');
+    expect(typeof extend).to.equal('function');
+    expect(typeof omit).to.equal('function');
+    expect(typeof pick).to.equal('function');
+  });
+
+  it('exposes lodash methods under _', () => {
+    expect(typeof _.each).to.equal('function');
+    expect(typeof _.some).to.equal('function');
+    expect(typeof _.every).to.equal('function');
+    expect(typeof _.keys).to.equal('function');
+    expect(typeof _.values).to.equal('function');
+    expect(typeof _.isMatch).to.equal('function');
+    expect(typeof _.isEmpty).to.equal('function');
+    expect(typeof _.extend).to.equal('function');
+    expect(typeof _.omit).to.equal('function');
+    expect(typeof _.pick).to.equal('function');
   });
 });


### PR DESCRIPTION
Exposing lodash-like functions so that they can just be included with es6 style syntax:

```js
import { omit } from 'feathers-commons';
```

Also added more tests around what is actually being exposed and removed `selectMany` as that function doesn't even exist.