### PR TITLE
Deep merge and toObject

### DIFF
--- a/src/commons.js
+++ b/src/commons.js
@@ -1,6 +1,12 @@
 import getArguments from './arguments';
 import {
+  _,
   stripSlashes,
+  matcher,
+  sorter,
+  select,
+  makeUrl,
+  // lodash functions
   each,
   some,
   every,
@@ -8,14 +14,11 @@ import {
   values,
   isMatch,
   isEmpty,
+  isObject,
   extend,
   omit,
   pick,
-  matcher,
-  sorter,
-  _,
-  select,
-  makeUrl
+  merge
 } from './utils';
 import hooks from './hooks';
 
@@ -23,6 +26,12 @@ export default {
   _,
   getArguments,
   stripSlashes,
+  hooks,
+  matcher,
+  sorter,
+  select,
+  makeUrl,
+  // lodash functions
   each,
   some,
   every,
@@ -30,12 +39,9 @@ export default {
   values,
   isMatch,
   isEmpty,
+  isObject,
   extend,
   omit,
   pick,
-  hooks,
-  matcher,
-  sorter,
-  select,
-  makeUrl
+  merge
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ export function stripSlashes (name) {
 export function each (obj, callback) {
   if (obj && typeof obj.forEach === 'function') {
     obj.forEach(callback);
-  } else if (typeof obj === 'object') {
+  } else if (isObject(obj)) {
     Object.keys(obj).forEach(key => callback(obj[key], key));
   }
 }
@@ -38,6 +38,10 @@ export function isEmpty (obj) {
   return _.keys(obj).length === 0;
 }
 
+export function isObject (item) {
+  return (typeof item === 'object' && !Array.isArray(item) && item !== null);
+}
+
 export function extend (...args) {
   return Object.assign(...args);
 }
@@ -56,6 +60,20 @@ export function pick (source, ...keys) {
   return result;
 }
 
+export function merge (target, source) {
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        merge(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    });
+  }
+  return target;
+}
+
 export const _ = {
   each,
   some,
@@ -64,9 +82,11 @@ export const _ = {
   values,
   isMatch,
   isEmpty,
+  isObject,
   extend,
   omit,
-  pick
+  pick,
+  merge
 };
 
 export const specialFilters = {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -17,9 +17,11 @@ import {
   values,
   isMatch,
   isEmpty,
+  isObject,
   extend,
   omit,
-  pick
+  pick,
+  merge
 } from '../src/commons';
 
 describe('build', () => {
@@ -53,9 +55,11 @@ describe('build', () => {
     expect(typeof values).to.equal('function');
     expect(typeof isMatch).to.equal('function');
     expect(typeof isEmpty).to.equal('function');
+    expect(typeof isObject).to.equal('function');
     expect(typeof extend).to.equal('function');
     expect(typeof omit).to.equal('function');
     expect(typeof pick).to.equal('function');
+    expect(typeof merge).to.equal('function');
   });
 
   it('exposes lodash methods under _', () => {
@@ -66,8 +70,10 @@ describe('build', () => {
     expect(typeof _.values).to.equal('function');
     expect(typeof _.isMatch).to.equal('function');
     expect(typeof _.isEmpty).to.equal('function');
+    expect(typeof _.isObject).to.equal('function');
     expect(typeof _.extend).to.equal('function');
     expect(typeof _.omit).to.equal('function');
     expect(typeof _.pick).to.equal('function');
+    expect(typeof _.merge).to.equal('function');
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -23,6 +23,12 @@ describe('feathers-commons utils', () => {
   });
 
   describe('_', () => {
+    it('isObject', () => {
+      expect(_.isObject({})).to.equal(true);
+      expect(_.isObject([])).to.equal(false);
+      expect(_.isObject(null)).to.equal(false);
+    });
+
     it('each', () => {
       _.each({ hi: 'there' }, (value, key) => {
         expect(key).to.equal('hi');
@@ -99,6 +105,35 @@ describe('feathers-commons utils', () => {
       }, 'first', 'second')).to.deep.equal({
         first: 1,
         second: 2
+      });
+    });
+
+    it('merge', () => {
+      expect(_.merge({ hi: 'there' }, { name: 'david' })).to.deep.equal({
+        hi: 'there',
+        name: 'david'
+      });
+
+      expect(_.merge({}, { name: 'david' })).to.deep.equal({
+        name: 'david'
+      });
+
+      expect(_.merge({ name: 'david' }, {})).to.deep.equal({
+        name: 'david'
+      });
+
+      expect(_.merge({
+        hi: 'there',
+        my: {
+          name: { is: 'david' },
+          number: { is: 1 }
+        }
+      }, { my: { name: { is: 'eric' } } })).to.deep.equal({
+        hi: 'there',
+        my: {
+          number: { is: 1 },
+          name: { is: 'eric' }
+        }
       });
     });
   });


### PR DESCRIPTION
This adds deep `merge` and `isObject` functions and converts `each` to do a proper isObject check.

Adding these will allow me to remove all of the the individual lodash methods from all the auth plugins at least and likely a few more.

It is rebased off of #43 