### PR TITLE
matcher now doesn't blow up with null values. Closes #46

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -152,7 +152,7 @@ export function matcher (originalQuery) {
     }
 
     return _.every(query, (value, key) => {
-      if (typeof value === 'object') {
+      if (value !== null && typeof value === 'object') {
         return _.every(value, (target, filterType) => {
           if (specialFilters[filterType]) {
             const filter = specialFilters[filterType](key, target);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -370,6 +370,16 @@ describe('feathers-commons utils', () => {
       expect(!matches({ name: 'Eric', counter: 1 })).to.be.ok;
       expect(matches({ name: 'Marshall', counter: 0 })).to.be.ok;
     });
+
+    it('with null values', () => {
+      const matches = matcher({
+        counter: null,
+        name: { $in: ['Eric', 'Marshall'] }
+      });
+
+      expect(!matches({ name: 'Eric', counter: 0 })).to.be.ok;
+      expect(matches({ name: 'Marshall', counter: null })).to.be.ok;
+    });
   });
 
   describe('makeUrl', function () {


### PR DESCRIPTION
### Summary

Matcher now supports having `null` values.

Closes #46